### PR TITLE
Update Samsung Tracker

### DIFF
--- a/domains/samsung
+++ b/domains/samsung
@@ -2,3 +2,12 @@ nmetrics.samsung.com
 insights.samsung.com
 analytics.samsungknox.com
 bigdata.ssp.samsung.com
+samsung-com.112.2o7.net
+samsungadhub.com
+demdex.net
+samsungads.com
+analytics-api.samsunghealthcn.com
+samsungacr.com
+samsungtvads.com
+samsungqbe.com
+tracking.apac.business.samsung.com


### PR DESCRIPTION
used Hagezi normal as a place to search for Samsung domains to block with rethinkdns domain searches to see which Samsung domains were being blocked in many blocklists that relate to tracking or ads. Should be safe from false positives due to the large amount of blocklists these domains here are in