### PR TITLE
Update Windows Tracker

### DIFF
--- a/domains/windows
+++ b/domains/windows
@@ -27,7 +27,10 @@ adnxs.com
 rad.msn.com
 rads.msn.com
 atdmt.com
+asimov-win.settings.data.microsoft.com.akadns.net
 
 # Office Telemetry
 onecollector.cloudapp.aria.akadns.net
 prod.nexusrules.live.com.akadns.net
+excel-telemetry.officeapps.live.com
+watson.officeint.microsoft.com

--- a/domains/windows
+++ b/domains/windows
@@ -23,6 +23,10 @@ cache.datamart.windows.com
 diagnostics.support.microsoft.com
 spynet2.microsoft.com
 spynetalt.microsoft.com
+adnxs.com
+rad.msn.com
+rads.msn.com
+atdmt.com
 
 # Office Telemetry
 onecollector.cloudapp.aria.akadns.net

--- a/domains/windows
+++ b/domains/windows
@@ -27,6 +27,7 @@ adnxs.com
 rad.msn.com
 rads.msn.com
 atdmt.com
+watson.events.data.microsoft.com
 asimov-win.settings.data.microsoft.com.akadns.net
 
 # Office Telemetry


### PR DESCRIPTION
adds domains that appear in windows spy blocker and many other blocklists. Used rethinkdns domain searches to see how many blocklist use each added domain here